### PR TITLE
Fixes mostly-adequate-guide/#269, adds Babel to part2_exercises/packa…

### DIFF
--- a/ch10.md
+++ b/ch10.md
@@ -148,6 +148,10 @@ Let's see this in use:
 ```js
 // checkEmail :: User -> Either String Email
 // checkName :: User -> Either String String
+const user = {
+  name: "John Doe",
+  email: "blurp_blurp"
+}
 
 //  createUser :: Email -> String -> IO User
 const createUser = curry((email, name) => { /* creating... */ })

--- a/code/part1_exercises/support.js
+++ b/code/part1_exercises/support.js
@@ -1,8 +1,5 @@
 //var curry = require('ramda').curry;
-//
-//
-//
-//
+
 function inspect(x) {
   return (typeof x === 'function') ? inspectFn(x) : inspectArgs(x);
 }
@@ -28,7 +25,7 @@ function curry(fx) {
     else {
       var f2 = function f2() {
         var args2 = Array.prototype.slice.call(arguments, 0);
-        return f1.apply(null, args.concat(args2)); 
+        return f1.apply(null, args.concat(args2));
       }
       f2.toString = function() {
         return inspectFn(fx) + inspectArgs(args);
@@ -39,18 +36,19 @@ function curry(fx) {
 }
 
 compose = function() {
-  var fns = toArray(arguments),
+  var _arguments = Array.prototype.slice.call(arguments)
+  var fns = toArray(_arguments),
       arglen = fns.length;
 
   return function(){
     for(var i=arglen;--i>=0;) {
       var fn = fns[i]
-        , args = fn.length ? Array.prototype.slice.call(arguments, 0, fn.length) : arguments
-        , next_args = Array.prototype.slice.call(arguments, (fn.length || 1)); //not right with *args
+        , args = fn.length ? Array.prototype.slice.call(_arguments, 0, fn.length) : _arguments
+        , next_args = Array.prototype.slice.call(_arguments, (fn.length || 1)); //not right with *args
       next_args.unshift(fn.apply(this,args));
-      arguments = next_args;
+      _arguments = next_args;
     }
-    return arguments[0];
+    return _arguments[0];
   }
 }
 

--- a/code/part2_exercises/README.md
+++ b/code/part2_exercises/README.md
@@ -5,11 +5,11 @@ Part 2 Exercises
 `npm install`
 
 **Running tests**:
-Tests are located in their corresponding folders.  To run:
+There are two npm scripts for running tests:
 
 ```
-cd exercises/curry
-mocha *spec.js
+npm run exercises
+npm run answers
 ```
 
-Some will fail and some will pass. You'll need to edit the exercises until the tests pass.
+Your homework is to edit the exercise files until all the tests pass.

--- a/code/part2_exercises/answers/functors/functor_exercises.js
+++ b/code/part2_exercises/answers/functors/functor_exercises.js
@@ -32,12 +32,9 @@ var ex3 = _.compose(_.map(_.head), safeProp('name'));
 // Exercise 4
 // ==========
 // Use Maybe to rewrite ex4 without an if statement
+let ex4 = n => (n === null || n === undefined) ? null : parseInt(n)
 
-var ex4 = function (n) {
-  if (n) { return parseInt(n); }
-};
-
-var ex4 = _.compose(_.map(parseInt), Maybe.of);
+ex4 = _.compose(_.map(parseInt), Maybe.of);
 
 
 // Exercise 5
@@ -48,7 +45,7 @@ var ex4 = _.compose(_.map(parseInt), Maybe.of);
 var getPost = function (i) {
   return new Task(function(rej, res) {
     setTimeout(function(){
-      res({id: i, title: 'Love them futures'})  
+      res({id: i, title: 'Love them futures'})
     }, 300)
   });
 };

--- a/code/part2_exercises/exercises/functors/functor_exercises.js
+++ b/code/part2_exercises/exercises/functors/functor_exercises.js
@@ -32,13 +32,10 @@ var ex3 = undefined;
 
 // Exercise 4
 // ==========
-// Use Maybe to rewrite ex4 without an if statement
+// Use Maybe to rewrite ex4 without a conditional operator
+let ex4 = n => (n === null || n === undefined) ? null : parseInt(n)
 
-var ex4 = function (n) {
-  if (n) { return parseInt(n); }
-};
-
-var ex4 = undefined;
+ex4 = undefined;
 
 
 
@@ -50,7 +47,7 @@ var ex4 = undefined;
 var getPost = function (i) {
   return new Task(function(rej, res) {
     setTimeout(function(){
-      res({id: i, title: 'Love them futures'})  
+      res({id: i, title: 'Love them futures'})
     }, 300)
   });
 };

--- a/code/part2_exercises/package.json
+++ b/code/part2_exercises/package.json
@@ -9,10 +9,14 @@
     "ramda": "^0.13.0"
   },
   "devDependencies": {
-    "mocha": "^1.17.1"
+    "babel-cli": "^6.9.0",
+    "babel-core": "^6.9.0",
+    "babel-preset-es2015": "^6.9.0",
+    "mocha": "^1.21.5"
   },
   "scripts": {
-    "test": "mocha exercises/**/*_spec.js"
+    "exercises": "mocha --require babel-core/register ./exercises/**/*_spec.js",
+    "answers": "mocha --require babel-core/register ./answers/**/*_spec.js"
   },
   "repository": {
     "type": "git",

--- a/code/part2_exercises/support.js
+++ b/code/part2_exercises/support.js
@@ -3,16 +3,16 @@ var _ = require('ramda');
 var Task = require('data.task');
 var curry = _.curry;
 
-inspect = function(x) {
+global.inspect = function(x) {
   return (x && x.inspect) ? x.inspect() : x;
 };
 
-toUpperCase = function(x) {
+global.toUpperCase = function(x) {
   return x.toUpperCase();
 };
 
 // Identity
-Identity = function(x) {
+global.Identity = function(x) {
   this.__value = x;
 };
 
@@ -27,7 +27,7 @@ Identity.prototype.inspect = function() {
 };
 
 // Maybe
-Maybe = function(x) {
+global.Maybe = function(x) {
   this.__value = x;
 };
 
@@ -61,12 +61,12 @@ Maybe.prototype.inspect = function() {
 
 
 // Either
-Either = function() {};
+global.Either = function() {};
 Either.of = function(x) {
   return new Right(x);
 }
 
-Left = function(x) {
+global.Left = function(x) {
   this.__value = x;
 }
 
@@ -84,7 +84,7 @@ Left.prototype.inspect = function() {
 }
 
 
-Right = function(x) {
+global.Right = function(x) {
   this.__value = x;
 }
 
@@ -124,7 +124,7 @@ Right.prototype.inspect = function() {
 }
 
 // IO
-IO = function(f) {
+global.IO = function(f) {
   this.unsafePerformIO = f;
 }
 
@@ -156,9 +156,9 @@ IO.prototype.inspect = function() {
   return 'IO('+inspect(this.unsafePerformIO)+')';
 }
 
-unsafePerformIO = function(x) { return x.unsafePerformIO(); }
+global.unsafePerformIO = function(x) { return x.unsafePerformIO(); }
 
-either = curry(function(f, g, e) {
+global.either = curry(function(f, g, e) {
   switch(e.constructor) {
     case Left: return f(e.__value);
     case Right: return g(e.__value);
@@ -166,17 +166,17 @@ either = curry(function(f, g, e) {
 });
 
 // overwriting join from pt 1
-join = function(m){ return m.join(); };
+global.join = function(m){ return m.join(); };
 
-chain = curry(function(f, m){
+global.chain = curry(function(f, m){
   return m.map(f).join(); // or compose(join, map(f))(m)
 });
 
-liftA2 = curry(function(f, a1, a2){
+global.liftA2 = curry(function(f, a1, a2){
   return a1.map(f).ap(a2);
 });
 
-liftA3 = curry(function(f, a1, a2, a3){
+global.liftA3 = curry(function(f, a1, a2, a3){
   return a1.map(f).ap(a2).ap(a3);
 });
 


### PR DESCRIPTION
…ge.json to allow Mocha tests to run with ES6 syntax, modifies `part2_exercises/package.json` scripts, modifies `part2_exercises/readme.md` to reflect script changes

I ran into a couple problems after setting up babel.

SyntaxError in `part1_exercises/support.js`: Assigning to arguments in strict mode (51:6)
- resolved with `var _arguments = Array.prototype.slice.call(arguments)`

ReferenceErrors for global variables in `part2_exercises/support.js`
- resolved by adding `global.` prefix to global variables

side note: I find it odd that there are separate package.json for part1 and part2. It seems like these should be merged so that there is only one package.json for both.